### PR TITLE
Interval sampling for  is non uniform

### DIFF
--- a/src/main/python/alppaca/scheduler.py
+++ b/src/main/python/alppaca/scheduler.py
@@ -46,7 +46,7 @@ class Scheduler(object):
             logger.warn("Expiration date is in the past, triggering now!")
             refresh_delta = 0
         else:
-            refresh_delta = int(round(refresh_delta / uniform(1.2, 2), 0))
+            refresh_delta = int(uniform(refresh_delta * .5, refresh_delta * .9))
         return refresh_delta
 
     def build_trigger(self, refresh_delta):

--- a/src/unittest/python/scheduler_tests.py
+++ b/src/unittest/python/scheduler_tests.py
@@ -43,7 +43,7 @@ class TestDetermineRefreshDelta(TestCase):
 
         with patch('alppaca.scheduler.uniform') as uniform_mock:
             datetime.datetime = FixedDateTime
-            uniform_mock.return_value = 1.2
+            uniform_mock.return_value = expected
 
             scheduler = Scheduler(Mock(), Mock())
 
@@ -54,7 +54,7 @@ class TestDetermineRefreshDelta(TestCase):
     def test_should_return_positive_refresh_delta_when_expiration_is_in_the_future(self):
 
         expiration = datetime.datetime(2015, 6, 22, 0, 0, 12, tzinfo=pytz.utc)
-        expected = 10
+        expected = 12
         self.helper(expected, expiration)
 
     def test_should_return_zero_refresh_delta_when_expiration_is_now(self):


### PR DESCRIPTION
I had a closer look at the distribution that we sample from to determine the next refresh and it seems to be non-uniform:

```
In [2]: from random import uniform                                                                                                

In [3]: def func(x=10): return int(round(x / uniform(1.2, 2)))

In [6]: d = [func(1000) for _ in range(10000000)]
%pylab 
In [7]: %pylab 
Using matplotlib backend: Qt4Agg
Populating the interactive namespace from numpy and matplotlib
WARNING: pylab import has clobbered these variables: ['uniform']
`%matplotlib` prevents importing * from pylab and numpy

In [8]: hist(d)
Out[8]: 
(array([ 1570532.,  1364064.,  1214846.,  1121172.,   976654.,   884512.,
          828091.,   731871.,   673405.,   634853.]),
 array([ 500. ,  533.3,  566.6,  599.9,  633.2,  666.5,  699.8,  733.1,
         766.4,  799.7,  833. ]),
 <a list of 10 Patch objects>)

```

The resulting histogram is here:

![sampling](https://cloud.githubusercontent.com/assets/41563/8475828/49962c86-20bb-11e5-8372-2e918a803d64.png)
