### PR TITLE
adding a test for the 500er

### DIFF
--- a/src/unittest/python/ims_interface_tests.py
+++ b/src/unittest/python/ims_interface_tests.py
@@ -1,3 +1,5 @@
+import textwrap
+
 import mock
 import requests_mock
 import requests
@@ -68,6 +70,23 @@ class IMSInterfaceTestGetCredentials(unittest.TestCase):
         mock_object.get(requests_mock.ANY, status_code=400)
         self.assertRaises(NoCredentialsFoundException, self.imsi.get_credentials, "test_role")
 
+    @requests_mock.mock()
+    def test_should_raise_no_credentials_found_exception_when_role_can_not_be_assumed(self, mock_object):
+        response = textwrap.dedent("""
+                                   {"timestamp":1436349287404,
+                                    "status":500,
+                                    "error":"Internal Server Error",
+                                    "exception":"com.amazonaws.AmazonServiceException",
+                                    "message":"User: arn:aws:iam::202084488265:user/federation-user-proxy
+                                     is not authorized to perform: sts:AssumeRole
+                                     on resource: arn:aws:iam::202084488265:role/rz_devesc
+                                     (Service: AWSSecurityTokenService; Status Code: 403; 
+                                      Error Code: AccessDenied; Request ID:
+                                      5df35a2d-2557-11e5-8899-b7abe26301a6)",
+                                    "path":"/latest/meta-data/iam/security-credentials/rz_devesc"}
+                                   """)
+        mock_object.get(requests_mock.ANY, status_code=500, text=response)
+        self.assertRaises(NoCredentialsFoundException, self.imsi.get_credentials, "test_role")
 
 class IMSInterfaceTestGetCredentialsForAllRoles(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This 500er is raised when the IMS/AFP can not assume the role for the machine. I.e. a misconfiguration within AWS. Currently the log will only show "500: internal server error and actual error text contained in the JSON response will be swallowed. 

Perhaps we should consider logging the JSON response by default? 
