### PR TITLE
do string formatting in logging framework

### DIFF
--- a/src/main/python/alppaca/assume_role.py
+++ b/src/main/python/alppaca/assume_role.py
@@ -1,10 +1,13 @@
 from __future__ import print_function, absolute_import, unicode_literals, division
 
+import json
+import logging
+import socket
+
 from alppaca import NoCredentialsFoundException
 from alppaca.compat import OrderedDict
-import json
+
 from boto.sts import connect_to_region
-import socket
 
 
 class AssumedRoleCredentialsProvider():
@@ -13,30 +16,36 @@ class AssumedRoleCredentialsProvider():
         self.role_to_assume = role_to_assume
         self.aws_proxy_host = aws_proxy_host
         self.aws_proxy_port = aws_proxy_port
+        self.logger = logging.getLogger(__name__)
 
     def get_credentials_for_all_roles(self):
         original_credentials = self.credentials_provider.get_credentials_for_all_roles()
         if not original_credentials:
-            raise NoCredentialsFoundException("Got not get credentials from: " + str(self.credentials_provider))
+            raise NoCredentialsFoundException("Got no credentials from: " + str(self.credentials_provider))
 
         for role in original_credentials:
             access_key, secret_key, token = self.parse_credentials_json(original_credentials[role])
-            return self.get_assume_role_credentials(access_key, secret_key, token)
+            return self.get_credentials_for_assumed_role(access_key, secret_key, token)
 
     @staticmethod
     def parse_credentials_json(credentials_json):
         credentials_dict = json.loads(credentials_json)
         return credentials_dict['AccessKeyId'], credentials_dict['SecretAccessKey'], credentials_dict['Token']
 
-    def get_assume_role_credentials(self, access_key, secret_key, token):
+    def get_credentials_for_assumed_role(self, access_key, secret_key, token):
+        self.logger.info("Connecting to AWS region eu-central-1 ...")
         conn = connect_to_region('eu-central-1',
-                                          aws_access_key_id=access_key,
-                                          aws_secret_access_key=secret_key,
-                                          security_token=token,
-                                          proxy=self.aws_proxy_host,
-                                          proxy_port=self.aws_proxy_port
-                                          )
-        response = conn.assume_role(role_arn=self.role_to_assume, role_session_name=self.get_session_name())
+                                 aws_access_key_id=access_key,
+                                 aws_secret_access_key=secret_key,
+                                 security_token=token,
+                                 proxy=self.aws_proxy_host,
+                                 proxy_port=self.aws_proxy_port
+                                 )
+        try:
+            response = conn.assume_role(role_arn=self.role_to_assume, role_session_name=self.get_session_name())
+            self.logger.info("Successfully got credentials for role: %s", self.role_to_assume)
+        finally:
+            conn.close()
 
         results = OrderedDict()
         results[self.get_role_name()] = self.create_credentials_json(response)

--- a/src/main/python/alppaca/ims_interface.py
+++ b/src/main/python/alppaca/ims_interface.py
@@ -38,8 +38,7 @@ class IMSCredentialsProvider(object):
                 self.logger.debug("Loaded roles: {0}".format(roles_list))
                 return roles_list
             else:
-                self.logger.error('Request to "{0}" failed'.format(
-                    request_url))
+                self.logger.error('Request to "%s" failed', request_url)
                 response.raise_for_status()
         except Exception as e:
             self.logger.exception("Due to following cause:")
@@ -55,7 +54,7 @@ class IMSCredentialsProvider(object):
                 role=role))
             if response.status_code == 200:
                 if not response.text:
-                    raise NoCredentialsFoundException("Server response was empty; no credentials for role?")
+                    raise NoCredentialsFoundException("Server response was empty; no credentials for role: {0}".format(role))
                 return response.text
             else:
                 response.raise_for_status()
@@ -72,7 +71,7 @@ class IMSCredentialsProvider(object):
                 try:
                     results[role] = self.get_credentials(role)
                 except NoCredentialsFoundException:
-                    self.logger.exception("Role {0} didn't have any credentials.".format(role))
+                    self.logger.exception("Role %s didn't have any credentials.", role)
         except NoRolesFoundException:
             self.logger.exception("Could not find any roles")
         return results

--- a/src/main/python/alppaca/scheduler.py
+++ b/src/main/python/alppaca/scheduler.py
@@ -41,7 +41,7 @@ class Scheduler(object):
         self.logger.info("Successfully completed credentials refresh")
 
     def job_failed_event_listener(self, event):
-        self.logger.error("Failed to refresh credentials: {0}".format(event.exception))
+        self.logger.error("Failed to refresh credentials: %s", event.exception)
 
     def do_backoff(self):
         """ Perform back-off and safety. """
@@ -66,7 +66,7 @@ class Scheduler(object):
     def update_credentials(self, cached_credentials):
         """ Update credentials and retrigger refresh """
         self.credentials.update(cached_credentials)
-        self.logger.info("Got credentials: {0}".format(self.credentials))
+        self.logger.info("Got credentials: %s", self.credentials)
         refresh_delta = self.extract_refresh_delta()
         if refresh_delta < 0:
             self.logger.warn("Expiration date is in the past, enter backoff.")
@@ -81,7 +81,7 @@ class Scheduler(object):
     def extract_refresh_delta(self):
         """ Return shortest expiration time in seconds. """
         expiration = isodate.parse_datetime(extract_min_expiration(self.credentials))
-        self.logger.info("Extracted expiration: {0}".format(expiration))
+        self.logger.info("Extracted expiration: %s", expiration)
         refresh_delta = total_seconds(expiration - datetime.datetime.now(tz=pytz.utc))
         return refresh_delta
 
@@ -92,7 +92,7 @@ class Scheduler(object):
 
     def build_trigger(self, refresh_delta):
         """ Actually add the trigger to the apscheduler. """
-        self.logger.info("Setting up trigger to fire in {0} seconds".format(refresh_delta))
+        self.logger.info("Setting up trigger to fire in %s seconds", refresh_delta)
         self.scheduler.add_job(func=self.refresh_credentials, trigger=DelayTrigger(refresh_delta))
 
 


### PR DESCRIPTION
A small fix that is more a general code style issue, I had in mind. Normally, you should let the logging framework do the string formatting stuff to avoid unneccessary formations if the log level is warn or error.
You do this for performance reasons if you have a log of debug messages for example. Here, the performance improvement isn't relevant, it's more a general remark.
