### PR TITLE
Fix #18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,7 @@ venv
 # IDEA project files
 *.iml
 .idea/
+
+# VirtualEnv
+bin/
+include/

--- a/src/main/python/alppaca/assume_role.py
+++ b/src/main/python/alppaca/assume_role.py
@@ -57,7 +57,7 @@ class AssumedRoleCredentialsProvider():
 
     @staticmethod
     def get_session_name():
-        return 'alppaca-session-of-' + socket.gethostname()
+        return 'alppaca-on-' + socket.gethostname()
 
     def get_role_name(self):
         return self.role_to_assume.split('/')[1]

--- a/src/main/python/alppaca/assume_role.py
+++ b/src/main/python/alppaca/assume_role.py
@@ -34,18 +34,22 @@ class AssumedRoleCredentialsProvider():
 
     def get_credentials_for_assumed_role(self, access_key, secret_key, token):
         self.logger.info("Connecting to AWS region eu-central-1 ...")
-        conn = connect_to_region('eu-central-1',
-                                 aws_access_key_id=access_key,
-                                 aws_secret_access_key=secret_key,
-                                 security_token=token,
-                                 proxy=self.aws_proxy_host,
-                                 proxy_port=self.aws_proxy_port
-                                 )
         try:
-            response = conn.assume_role(role_arn=self.role_to_assume, role_session_name=self.get_session_name())
-            self.logger.info("Successfully got credentials for role: %s", self.role_to_assume)
-        finally:
-            conn.close()
+            conn = connect_to_region('eu-central-1',
+                                     aws_access_key_id=access_key,
+                                     aws_secret_access_key=secret_key,
+                                     security_token=token,
+                                     proxy=self.aws_proxy_host,
+                                     proxy_port=self.aws_proxy_port
+                                     )
+            try:
+                response = conn.assume_role(role_arn=self.role_to_assume, role_session_name=self.get_session_name())
+                self.logger.info("Successfully got credentials for role: %s", self.role_to_assume)
+            finally:
+                conn.close()
+        except Exception as e:
+            self.logger.exception("Could not assume the AWS role:")
+            raise NoCredentialsFoundException(str(e))
 
         results = OrderedDict()
         results[self.get_role_name()] = self.create_credentials_json(response)

--- a/src/main/python/alppaca/assume_role.py
+++ b/src/main/python/alppaca/assume_role.py
@@ -33,6 +33,8 @@ class AssumedRoleCredentialsProvider():
         return credentials_dict['AccessKeyId'], credentials_dict['SecretAccessKey'], credentials_dict['Token']
 
     def get_credentials_for_assumed_role(self, access_key, secret_key, token):
+        results = OrderedDict()
+
         self.logger.info("Connecting to AWS region eu-central-1 ...")
         try:
             conn = connect_to_region('eu-central-1',
@@ -47,12 +49,9 @@ class AssumedRoleCredentialsProvider():
                 self.logger.info("Successfully got credentials for role: %s", self.role_to_assume)
             finally:
                 conn.close()
+            results[self.get_role_name()] = self.create_credentials_json(response)
         except Exception as e:
             self.logger.exception("Could not assume the AWS role:")
-            raise NoCredentialsFoundException(str(e))
-
-        results = OrderedDict()
-        results[self.get_role_name()] = self.create_credentials_json(response)
 
         return results
 

--- a/src/unittest/python/assume_role_tests.py
+++ b/src/unittest/python/assume_role_tests.py
@@ -1,13 +1,17 @@
 from __future__ import print_function, absolute_import, unicode_literals, division
+
 import json
-from boto.sts.credentials import Credentials
-from boto.sts.credentials import AssumedRole
-from alppaca import NoCredentialsFoundException
 
 from mock import patch, Mock
 
+from alppaca import NoCredentialsFoundException
 from alppaca.compat import OrderedDict, unittest
 from alppaca.assume_role import AssumedRoleCredentialsProvider
+
+from boto.exception import BotoServerError
+from boto.sts.credentials import AssumedRole
+from boto.sts.credentials import Credentials
+
 
 ROLE = 'my_role'
 ROLE_ARN = 'arn:aws:iam::123456789012:role/%s' % ROLE
@@ -15,6 +19,7 @@ ANOTHER_EXPIRATION = "NEW_EXPI"
 ANOTHER_TOKEN = "NEW_TOKEN"
 ANOTHER_SECRET = "NEW_SECRET"
 ANOTHER_KEY = "NEW_KEY"
+DUMMY_CREDENTIALS = {'ims_role': '{"AccessKeyId": "ACCESS_KEY", "SecretAccessKey": "SECRET", "Token": "MY_TOKEN"}'}
 
 
 class AssumeRoleCredentialsProviderTest(unittest.TestCase):
@@ -31,9 +36,7 @@ class AssumeRoleCredentialsProviderTest(unittest.TestCase):
 
     @patch('alppaca.assume_role.connect_to_region')
     def test_should_give_credentials(self, sts_mock):
-        self.credentials_provider_mock.get_credentials_for_all_roles.return_value = {
-            'ims_role': '{"AccessKeyId": "ACCESS_KEY", "SecretAccessKey": "SECRET", "Token": "MY_TOKEN"}'
-        }
+        self.credentials_provider_mock.get_credentials_for_all_roles.return_value = DUMMY_CREDENTIALS
 
         given_credentials = Credentials()
         given_credentials.access_key = ANOTHER_KEY
@@ -51,6 +54,13 @@ class AssumeRoleCredentialsProviderTest(unittest.TestCase):
 
         credentials = self.provider.get_credentials_for_all_roles()
         self.assertEqual(given_credentials_string, credentials[ROLE])
+
+    @patch('alppaca.assume_role.connect_to_region')
+    def test_should_raise_exception_for_failed_boto_call(self, sts_mock):
+        self.credentials_provider_mock.get_credentials_for_all_roles.return_value = DUMMY_CREDENTIALS
+        sts_mock.return_value.assume_role.side_effect = Exception('Boom!')
+        with self.assertRaises(NoCredentialsFoundException):
+            self.provider.get_credentials_for_all_roles()
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/unittest/python/assume_role_tests.py
+++ b/src/unittest/python/assume_role_tests.py
@@ -56,11 +56,11 @@ class AssumeRoleCredentialsProviderTest(unittest.TestCase):
         self.assertEqual(given_credentials_string, credentials[ROLE])
 
     @patch('alppaca.assume_role.connect_to_region')
-    def test_should_raise_exception_for_failed_boto_call(self, sts_mock):
+    def test_should_return_empty_dict_for_failed_boto_call(self, sts_mock):
         self.credentials_provider_mock.get_credentials_for_all_roles.return_value = DUMMY_CREDENTIALS
         sts_mock.return_value.assume_role.side_effect = Exception('Boom!')
-        with self.assertRaises(NoCredentialsFoundException):
-            self.provider.get_credentials_for_all_roles()
+        result = self.provider.get_credentials_for_all_roles()
+        self.assertEqual(result, OrderedDict())
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Now, all boto exceptions get caught, so alppace service should start independent of the result.
