### PR TITLE
automatically restart alppaca

### DIFF
--- a/src/main/python/resources/alppaca.conf
+++ b/src/main/python/resources/alppaca.conf
@@ -1,0 +1,7 @@
+# Start the application as Upstart service job
+description "Mimics the AWS meta-data service on link-local 169.254.169.254 for fetching IAM role based credentials for instances not based in EC2"
+author  "ImmobilienScout24"
+start on filesystem or runlevel [2345]
+stop on runlevel [!2345]
+respawn
+exec su -l -s /bin/sh -c "exec /usr/bin/alppacad" alppaca


### PR DESCRIPTION
As alppaca needs to run _always_ on the machines, please use a mechanism which will automatically restart alppaca upon "death". For example use an upstart module or a systemd unit for this.
